### PR TITLE
Make underlaying managed object context of context public accessible

### DIFF
--- a/Examples/iOS/AlecrimCoreDataExample/AppDelegate.swift
+++ b/Examples/iOS/AlecrimCoreDataExample/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import CoreData
+import AlecrimCoreData
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDelegate {
@@ -24,6 +25,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
         let masterNavigationController = splitViewController.viewControllers[0] as UINavigationController
         let controller = masterNavigationController.topViewController as MasterViewController
+        
+        println(localSQLiteStoreURLForBundle(NSBundle.mainBundle()))
 
         return true
     }

--- a/Examples/iOS/AlecrimCoreDataExample/MasterViewController.swift
+++ b/Examples/iOS/AlecrimCoreDataExample/MasterViewController.swift
@@ -148,7 +148,7 @@ class MasterViewController: UITableViewController {
 
     func configureCell(cell: UITableViewCell, atIndexPath indexPath: NSIndexPath) {
         let entity = self.fetchedResultsController.entityAtIndexPath(indexPath)
-        cell.textLabel.text = entity.timeStamp.description
+        cell.textLabel?.text = entity.timeStamp.description
     }
 
 }

--- a/Source/Shared/AlecrimCoreData/Classes/Context.swift
+++ b/Source/Shared/AlecrimCoreData/Classes/Context.swift
@@ -12,7 +12,7 @@ import CoreData
 public class Context {
     
     private let stack: Stack!
-    internal let managedObjectContext: NSManagedObjectContext!
+    public let managedObjectContext: NSManagedObjectContext!
     
     public init?(managedObjectModelName: String? = nil, stackType: StackType = StackType.SQLite) {
         if let stack = Stack(managedObjectModelName: managedObjectModelName, stackType: stackType) {

--- a/Source/Shared/AlecrimCoreData/Classes/Stack.swift
+++ b/Source/Shared/AlecrimCoreData/Classes/Stack.swift
@@ -124,14 +124,9 @@ internal final class Stack {
     
     private class func persistentStoreForSQLiteStoreTypeWithCoordinator(coordinator: NSPersistentStoreCoordinator, managedObjectModelName: String?, bundle: NSBundle) -> NSPersistentStore? {
         if let momn = managedObjectModelName {
-            let fileManager = NSFileManager.defaultManager()
-            let urls = fileManager.URLsForDirectory(.ApplicationSupportDirectory, inDomains: .UserDomainMask)
-            let applicationSupportDirectoryURL = urls[urls.endIndex - 1] as NSURL
-            
-            if let bundleIdentifier = bundle.bundleIdentifier {
-                let localStoreURL = applicationSupportDirectoryURL.URLByAppendingPathComponent(bundleIdentifier, isDirectory: true)
-                
-                if let localStorePath = localStoreURL.absoluteString {
+            if let localStoreURL = localSQLiteStoreURLForBundle(bundle) {
+                if let localStorePath = localStoreURL.path {
+                    let fileManager = NSFileManager.defaultManager()
                     var error: NSError? = nil
                     
                     if !fileManager.fileExistsAtPath(localStorePath) {
@@ -140,15 +135,14 @@ internal final class Stack {
                             return nil
                         }
                     }
-                    
-                    let storeFilename = momn.stringByAppendingPathExtension("sqlite")!
-                    let localStoreFileURL = localStoreURL.URLByAppendingPathComponent(storeFilename, isDirectory: false)
-                    
-                    return coordinator.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: localStoreFileURL, options: nil, error: nil)!
                 }
+                
+                let storeFilename = momn.stringByAppendingPathExtension("sqlite")!
+                let localStoreFileURL = localStoreURL.URLByAppendingPathComponent(storeFilename, isDirectory: false)
+                
+                return coordinator.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: localStoreFileURL, options: nil, error: nil)!
             }
         }
-        
         return nil
     }
     
@@ -189,4 +183,16 @@ private class StackBackgroundManagedObjectContext: NSManagedObjectContext {
         }
     }
     
+}
+
+public func localSQLiteStoreURLForBundle(bundle: NSBundle) -> NSURL? {
+    let fileManager = NSFileManager.defaultManager()
+    let urls = fileManager.URLsForDirectory(.ApplicationSupportDirectory, inDomains: .UserDomainMask)
+    let applicationSupportDirectoryURL = urls.last as NSURL
+    
+    if let bundleIdentifier = bundle.bundleIdentifier {
+        return applicationSupportDirectoryURL.URLByAppendingPathComponent(bundleIdentifier, isDirectory: true)
+    }
+    
+    return nil
 }

--- a/Source/iOS/AlecrimCoreData/Extensions/FetchedResultsController+Extensions.swift
+++ b/Source/iOS/AlecrimCoreData/Extensions/FetchedResultsController+Extensions.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Alecrim. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 // MARK: - UITableView helper methods
 


### PR DESCRIPTION
sometimes you just need to access the actual managed object context to perform certain tasks …

e.g see #20