### PR TITLE
Added function to access sqlite storage path

### DIFF
--- a/Examples/iOS/AlecrimCoreDataExample/AppDelegate.swift
+++ b/Examples/iOS/AlecrimCoreDataExample/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import CoreData
+import AlecrimCoreData
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDelegate {
@@ -24,6 +25,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
         let masterNavigationController = splitViewController.viewControllers[0] as UINavigationController
         let controller = masterNavigationController.topViewController as MasterViewController
+        
+        println(localSQLiteStoreURLForBundle(NSBundle.mainBundle()))
 
         return true
     }

--- a/Examples/iOS/AlecrimCoreDataExample/MasterViewController.swift
+++ b/Examples/iOS/AlecrimCoreDataExample/MasterViewController.swift
@@ -148,7 +148,7 @@ class MasterViewController: UITableViewController {
 
     func configureCell(cell: UITableViewCell, atIndexPath indexPath: NSIndexPath) {
         let entity = self.fetchedResultsController.entityAtIndexPath(indexPath)
-        cell.textLabel.text = entity.timeStamp.description
+        cell.textLabel?.text = entity.timeStamp.description
     }
 
 }

--- a/Source/Shared/AlecrimCoreData/Classes/Stack.swift
+++ b/Source/Shared/AlecrimCoreData/Classes/Stack.swift
@@ -124,14 +124,9 @@ internal final class Stack {
     
     private class func persistentStoreForSQLiteStoreTypeWithCoordinator(coordinator: NSPersistentStoreCoordinator, managedObjectModelName: String?, bundle: NSBundle) -> NSPersistentStore? {
         if let momn = managedObjectModelName {
-            let fileManager = NSFileManager.defaultManager()
-            let urls = fileManager.URLsForDirectory(.ApplicationSupportDirectory, inDomains: .UserDomainMask)
-            let applicationSupportDirectoryURL = urls[urls.endIndex - 1] as NSURL
-            
-            if let bundleIdentifier = bundle.bundleIdentifier {
-                let localStoreURL = applicationSupportDirectoryURL.URLByAppendingPathComponent(bundleIdentifier, isDirectory: true)
-                
-                if let localStorePath = localStoreURL.absoluteString {
+            if let localStoreURL = localSQLiteStoreURLForBundle(bundle) {
+                if let localStorePath = localStoreURL.path {
+                    let fileManager = NSFileManager.defaultManager()
                     var error: NSError? = nil
                     
                     if !fileManager.fileExistsAtPath(localStorePath) {
@@ -140,15 +135,14 @@ internal final class Stack {
                             return nil
                         }
                     }
-                    
-                    let storeFilename = momn.stringByAppendingPathExtension("sqlite")!
-                    let localStoreFileURL = localStoreURL.URLByAppendingPathComponent(storeFilename, isDirectory: false)
-                    
-                    return coordinator.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: localStoreFileURL, options: nil, error: nil)!
                 }
+                
+                let storeFilename = momn.stringByAppendingPathExtension("sqlite")!
+                let localStoreFileURL = localStoreURL.URLByAppendingPathComponent(storeFilename, isDirectory: false)
+                
+                return coordinator.addPersistentStoreWithType(NSSQLiteStoreType, configuration: nil, URL: localStoreFileURL, options: nil, error: nil)!
             }
         }
-        
         return nil
     }
     
@@ -189,4 +183,16 @@ private class StackBackgroundManagedObjectContext: NSManagedObjectContext {
         }
     }
     
+}
+
+public func localSQLiteStoreURLForBundle(bundle: NSBundle) -> NSURL? {
+    let fileManager = NSFileManager.defaultManager()
+    let urls = fileManager.URLsForDirectory(.ApplicationSupportDirectory, inDomains: .UserDomainMask)
+    let applicationSupportDirectoryURL = urls.last as NSURL
+    
+    if let bundleIdentifier = bundle.bundleIdentifier {
+        return applicationSupportDirectoryURL.URLByAppendingPathComponent(bundleIdentifier, isDirectory: true)
+    }
+    
+    return nil
 }


### PR DESCRIPTION
This is especially useful when pre-bundling an existing database that needs to copied into the correct folder on first launch.