### PR TITLE
Fix caching for NSEntityDescription

### DIFF
--- a/Source/AlecrimCoreData.xcodeproj/project.pbxproj
+++ b/Source/AlecrimCoreData.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		14CB03361B77960800EB87B8 /* NSFetchedResultsControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A5017B1B6739F40057DD8B /* NSFetchedResultsControllerExtensions.swift */; };
 		14CB03371B77960800EB87B8 /* UITableViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A501711B6732820057DD8B /* UITableViewExtensions.swift */; };
 		14CB03381B77960800EB87B8 /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A501731B6733890057DD8B /* UICollectionViewExtensions.swift */; };
+		91C57CC11C2451520020891C /* Duplet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C57CC01C2451520020891C /* Duplet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,6 +63,7 @@
 		14D565AC1B64B07E00B1EFF1 /* FetchRequestControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchRequestControllerDelegate.swift; sourceTree = "<group>"; };
 		14FBAD691B76AF2100EB662A /* AttributeQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributeQuery.swift; sourceTree = "<group>"; };
 		14FBAD6B1B76B23000EB662A /* CoreDataQueryable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataQueryable.swift; sourceTree = "<group>"; };
+		91C57CC01C2451520020891C /* Duplet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Duplet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +167,7 @@
 				145D972B1B5DA55C00995795 /* Table.swift */,
 				14FBAD691B76AF2100EB662A /* AttributeQuery.swift */,
 				143D67231B60D5F1001B6ED3 /* DataContextOptions.swift */,
+				91C57CC01C2451520020891C /* Duplet.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -278,6 +281,7 @@
 				14CB03231B77959400EB87B8 /* Attribute.swift in Sources */,
 				14CB032F1B7795F600EB87B8 /* DataContext.swift in Sources */,
 				14CB031D1B778FC400EB87B8 /* DataContextOptions.swift in Sources */,
+				91C57CC11C2451520020891C /* Duplet.swift in Sources */,
 				14CB031C1B778FBA00EB87B8 /* AttributeType.swift in Sources */,
 				14CB03321B7795F600EB87B8 /* FetchRequestControllerDelegate.swift in Sources */,
 				14CB03261B7795B400EB87B8 /* NSManagedObjectExtensions.swift in Sources */,

--- a/Source/AlecrimCoreData/Core/Structs/Duplet.swift
+++ b/Source/AlecrimCoreData/Core/Structs/Duplet.swift
@@ -1,0 +1,27 @@
+//
+//  Duplet.swift
+//  AlecrimCoreData
+//
+//  Created by Adam Szeptycki on 18/12/15.
+//  Copyright © 2015 Alecrim. All rights reserved.
+//
+
+import Foundation
+
+struct Duplet<A: Hashable, B: Hashable>: Hashable {
+    let one: A
+    let two: B
+    
+    var hashValue: Int {
+        return one.hashValue ^ two.hashValue
+    }
+    
+    init(_ one: A, _ two: B) {
+        self.one = one
+        self.two = two
+    }
+}
+
+func ==<A, B> (lhs: Duplet<A, B>, rhs: Duplet<A, B>) -> Bool {
+    return lhs.one == rhs.one && lhs.two == rhs.two
+}


### PR DESCRIPTION
Table was caching NSEntityDescription only based on Entity Name.
It leads to crash when you try to have multiple persistent stores with Entities with the same name.
Same crash could sometimes occure when developer tries to writes test using .InMemoryStore.