### PR TITLE
Make 'managedObjectContext' on `delete()`optional

### DIFF
--- a/Source/AlecrimCoreData/Core/Extensions/NSManagedObjectExtensions.swift
+++ b/Source/AlecrimCoreData/Core/Extensions/NSManagedObjectExtensions.swift
@@ -30,7 +30,7 @@ extension NSManagedObject {
 extension NSManagedObject {
     
     public func delete() {
-        self.managedObjectContext!.deleteObject(self)
+        self.managedObjectContext?.deleteObject(self)
     }
     
     public func refresh(mergeChanges: Bool = true) {


### PR DESCRIPTION
If the object isn't in a `managedObjectContext, the object won't be saved anywhere anyways, and this prevents possible crashes for explicitly unwrapping the context.