### PR TITLE
Remove the delegate when FetchRequestController deinits

### DIFF
--- a/Source/AlecrimCoreData/Core/Classes/FetchRequestController.swift
+++ b/Source/AlecrimCoreData/Core/Classes/FetchRequestController.swift
@@ -29,6 +29,10 @@ public final class FetchRequestController<T: NSManagedObject> {
     //
     internal lazy var delegate = FetchRequestControllerDelegate<T>()
 
+    deinit {
+        self.underlyingFetchedResultsController.delegate = nil
+    }
+
     /// The underlying NSFetchedResultsController managed by this controller.
     ///
     /// - discussion: DO NOT modify properties of the underlying fetched results controller directly, it is for integration with other libraries which need to fetch data using a FRC.


### PR DESCRIPTION
I've been having some issues lately with a very hard to track bug every time I hit `save` on a `DataContext`. I realized this happened only when I had some `FetchRequestController` instances (I have `UICollectionView`s inside `UITableViewCell`s.

Finally, I discovered that the issue was coming from an `NSFetchedResultsController` that was trying to access a `FetchRequestController` (AlecrimCoreData wrapper) pointer that was already freed from memory.

```
2016-05-05 13:10:02.044 Context[685:226043] -[NSFetchRequest controllerWillChangeContent:]: unrecognized selector sent to instance 0x15c55c4a0
2016-05-05 13:10:02.044 Context[685:226043] CoreData: error: Serious application error.  Exception was caught during Core Data change processing.  This is usually a bug within an observer of NSManagedObjectContextObjectsDidChangeNotification.  -[NSFetchRequest controllerWillChangeContent:]: unrecognized selector sent to instance 0x15c55c4a0 with userInfo (null)
2016-05-05 13:10:02.045 Context[685:226043] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSFetchRequest controllerWillChangeContent:]: unrecognized selector sent to instance 0x15c55c4a0'
*** First throw call stack:
(0x1816cd900 0x180d3bf80 0x1816d461c 0x1816d15b8 0x1815d568c 0x183257e7c 0x1831cd080 0x1831ccf48 0x18315d108 0x181672fc4 0x1816727e4 0x181672564 0x1816d7de4 0x1815b30f4 0x181fa2d2c 0x18315d06c 0x1831d18d0 0x18315b78c 0x18315a240 0x100e652b0 0x1002af4c4 0x100091ce0 0x100e7daf0 0x1831cd080 0x101c79bb0 0x101c7f658 0x181684bb0 0x181682a18 0x1815b1680 0x182ac0088 0x186428d90 0x10023ab28 0x1811528b8)
libc++abi.dylib: terminating with uncaught exception of type NSException
(lldb) 
```

Just by adding a `delegate = nil` to that underlying `NSFetchedResultsController` solves the problem.

That's why I'm doing this pull request :thumbsup: