### PR TITLE
Added 'isIn()' to 'NSManagedObject'

### DIFF
--- a/Source/AlecrimCoreData/Core/Extensions/NSManagedObjectExtensions.swift
+++ b/Source/AlecrimCoreData/Core/Extensions/NSManagedObjectExtensions.swift
@@ -38,3 +38,21 @@ extension NSManagedObject {
     }
 
 }
+
+extension NSManagedObject {
+    
+    public class func isIn(values: Set<NSManagedObject>) -> NSComparisonPredicate {
+        let rightExpressionConstantValues = values.map { NSExpression(forConstantValue: $0.objectID) }
+        let rightExpression = NSExpression(forAggregate: rightExpressionConstantValues)
+        let leftExpression = NSExpression(forKeyPath: "objectID")
+        
+        return NSComparisonPredicate(
+            leftExpression: leftExpression,
+            rightExpression: rightExpression,
+            modifier: .DirectPredicateModifier,
+            type: .InPredicateOperatorType,
+            options: NSComparisonPredicateOptions()
+        )
+    }
+    
+}


### PR DESCRIPTION
This adds the ability to us `isIn()` on an `NSManagedObject` type in predicate closures.

Example usage:

````swift
let childrenToFilterBy: Set<ChildEntity> = [child1, child2]

let table = context.entity.filter { $0.children.any({ $0.isIn(childrenToFilterBy }) }
````

This has been used and tested in my application and functions as expected.