### PR TITLE
Strong retain of tableView in extension

### DIFF
--- a/Source/AlecrimCoreData/Core/Extensions/UITableViewExtensions.swift
+++ b/Source/AlecrimCoreData/Core/Extensions/UITableViewExtensions.swift
@@ -46,9 +46,6 @@ extension FetchRequestController {
                 if !reloadData {
                     //
                     reset()
-                    
-                    //
-                    tableView.beginUpdates()
                 }
             }
             .didInsertSection { sectionInfo, sectionIndex in
@@ -124,6 +121,7 @@ extension FetchRequestController {
                     reset()
                 }
                 else {
+                    tableView.beginUpdates()
                     if deletedSectionIndexes.count > 0 {
                         tableView.deleteSections(deletedSectionIndexes, withRowAnimation: rowAnimation)
                     }


### PR DESCRIPTION
The call to `tableView.beginUpdates()` in `.willChangeContent` was creating a strong retain on the tableView var, which can cause ARC not to free it from memory.  Since you're keeping track of changes in lists anyways and performing the tableView changes in `.didChangeContent` it should be safe to move it there where the tableView is already a weak reference.