### PR TITLE
collectionView should be weak instead of unowned

### DIFF
--- a/Source/AlecrimCoreData/Core/Extensions/UICollectionViewExtensions.swift
+++ b/Source/AlecrimCoreData/Core/Extensions/UICollectionViewExtensions.swift
@@ -113,7 +113,12 @@
                         }
                     }
                 }
-                .didChangeContent { [unowned collectionView] in
+                .didChangeContent { [weak collectionView] in
+                    guard let collectionView = collectionView else {
+                        reset()
+                        return
+                    }
+                    
                     if reloadData {
                         collectionView.reloadData()
                         reset()


### PR DESCRIPTION
In the callback for .didChangeContent of a bound collectionView we are passing in collectionView as an unowned var.  It however can be nil, so should be passed in as weak and guarded around.  This was in a previous version of Alecrim, but seemed to be a reverted back.