### PR TITLE
CoreData store URL should be provided by GenericPersistentContainer

### DIFF
--- a/Source/AlecrimCoreData/Core/Classes/CustomPersistentContainer.swift
+++ b/Source/AlecrimCoreData/Core/Classes/CustomPersistentContainer.swift
@@ -96,7 +96,7 @@ internal class CustomPersistentContainer: NSObject, UnderlyingPersistentContaine
 
     // MARK: -
     
-    internal required init(name: String, managedObjectModel model: NSManagedObjectModel, contextType: NSManagedObjectContext.Type) {
+    internal required init(name: String, managedObjectModel model: NSManagedObjectModel, contextType: NSManagedObjectContext.Type, directoryURL: URL) {
         self.contextType = contextType
         
         self.name = name
@@ -105,7 +105,7 @@ internal class CustomPersistentContainer: NSObject, UnderlyingPersistentContaine
         self.viewContext = self.contextType.init(concurrencyType: .mainQueueConcurrencyType)
         self.viewContext.persistentStoreCoordinator = self.persistentStoreCoordinator
         
-        self.alc_persistentStoreDescriptions = [CustomPersistentStoreDescription(url: type(of: self).defaultDirectoryURL().appendingPathComponent("\(name).sqlite"))]
+        self.alc_persistentStoreDescriptions = [CustomPersistentStoreDescription(url: directoryURL.appendingPathComponent("\(name).sqlite"))]
     }
     
     // MARK: -

--- a/Source/AlecrimCoreData/Core/Classes/NativePersistentContainer.swift
+++ b/Source/AlecrimCoreData/Core/Classes/NativePersistentContainer.swift
@@ -20,12 +20,12 @@ internal class NativePersistentContainer: NSPersistentContainer, UnderlyingPersi
     
     internal override var viewContext: NSManagedObjectContext { return self._viewContext }
     
-    internal required init(name: String, managedObjectModel model: NSManagedObjectModel, contextType: NSManagedObjectContext.Type) {
+    internal required init(name: String, managedObjectModel model: NSManagedObjectModel, contextType: NSManagedObjectContext.Type, directoryURL: URL) {
         self.contextType = contextType
         self._viewContext = self.contextType.init(concurrencyType: .mainQueueConcurrencyType)
         
         super.init(name: name, managedObjectModel: model)
-        
+        self.persistentStoreDescriptions = [NSPersistentStoreDescription(url: directoryURL.appendingPathComponent("\(name).sqlite"))]
         self._viewContext.persistentStoreCoordinator = self.persistentStoreCoordinator
     }
     

--- a/Source/AlecrimCoreData/Core/Classes/PersistentContainer.swift
+++ b/Source/AlecrimCoreData/Core/Classes/PersistentContainer.swift
@@ -55,7 +55,7 @@ internal protocol UnderlyingPersistentContainer: class {
     
     func configureDefaults(for context: NSManagedObjectContext)
     
-    init(name: String, managedObjectModel model: NSManagedObjectModel, contextType: NSManagedObjectContext.Type)
+    init(name: String, managedObjectModel model: NSManagedObjectModel, contextType: NSManagedObjectContext.Type, directoryURL: URL)
 }
 
 // MARK: -
@@ -64,7 +64,7 @@ open class GenericPersistentContainer<ContextType: NSManagedObjectContext> {
 
     // MARK: -
 
-    open class func defaultDirectoryURL() -> URL {
+    open class func directoryURL() -> URL {
         if #available(iOS 10.0, macOSApplicationExtension 10.12, iOSApplicationExtension 10.0, tvOSApplicationExtension 10.0, watchOSApplicationExtension 3.0, *) {
             return NativePersistentContainer.defaultDirectoryURL()
         }
@@ -122,12 +122,14 @@ open class GenericPersistentContainer<ContextType: NSManagedObjectContext> {
     
     
     public init(name: String, managedObjectModel model: NSManagedObjectModel, automaticallyLoadPersistentStores: Bool) {
+        let directoryURL = type(of: self).directoryURL()
+        
         //
         if #available(iOS 10.0, macOSApplicationExtension 10.12, iOSApplicationExtension 10.0, tvOSApplicationExtension 10.0, watchOSApplicationExtension 3.0, *) {
-            self.underlyingPersistentContainer = NativePersistentContainer(name: name, managedObjectModel: model, contextType: ContextType.self)
+            self.underlyingPersistentContainer = NativePersistentContainer(name: name, managedObjectModel: model, contextType: ContextType.self, directoryURL: directoryURL)
         }
         else {
-            self.underlyingPersistentContainer = CustomPersistentContainer(name: name, managedObjectModel: model, contextType: ContextType.self)
+            self.underlyingPersistentContainer = CustomPersistentContainer(name: name, managedObjectModel: model, contextType: ContextType.self, directoryURL: directoryURL)
         }
         
         //

--- a/Source/AlecrimCoreData/Core/Classes/PersistentContainer.swift
+++ b/Source/AlecrimCoreData/Core/Classes/PersistentContainer.swift
@@ -124,6 +124,12 @@ open class GenericPersistentContainer<ContextType: NSManagedObjectContext> {
     public init(name: String, managedObjectModel model: NSManagedObjectModel, automaticallyLoadPersistentStores: Bool) {
         let directoryURL = type(of: self).directoryURL()
         
+        do {
+            try FileManager.default.createDirectory(atPath: directoryURL.path, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            AlecrimCoreDataError.handleError(error)
+        }
+        
         //
         if #available(iOS 10.0, macOSApplicationExtension 10.12, iOSApplicationExtension 10.0, tvOSApplicationExtension 10.0, watchOSApplicationExtension 3.0, *) {
             self.underlyingPersistentContainer = NativePersistentContainer(name: name, managedObjectModel: model, contextType: ContextType.self, directoryURL: directoryURL)


### PR DESCRIPTION
I tested this rolling forward from 4.x version of alecrim to 5.0 with both ios 9.3 and ios 10.2.

Before this change overriding the class func for defaultDirectoryURL didn't do anything as the underlyingPersistentContainer wasn't calling it.  Now it should be able to work.  Also, changed the name to directoryURL as it's not really a default.  Usage than looks like:

```
let container = MyPersistentContainer(name: "MyDataStore")

class MyPersistentContainer: GenericPersistentContainer<NSManagedObjectContext> {
    override class func directoryURL() -> URL {
        do {
            let applicationSupportUrl = try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
            return applicationSupportUrl.appendingPathComponent("/my.bundle.id/CoreData")
        } catch {
            fatalError("Error getting application support dir: \(error)")
        }
    }
}
```

